### PR TITLE
fix(docs): Removed redundant comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Overall discussion
 > Below are the roadmap features we intend to implement, send in some ideas!
 
 ### [Generic](./generic.md)
-> [!NOTE] 
-> No real markdown, things we generally want
 - Styling that you'd expect with keybinds you'd expect. (Bold, italics, etc.)
 - Notes, Expanded notes
 - Better bridge integration/support


### PR DESCRIPTION
No point adding the note/reminder of no markdown for the following list since itll be in the generic markdown list itself until a new one is created.